### PR TITLE
Add `log/slog` sinks to `logi`

### DIFF
--- a/check.go
+++ b/check.go
@@ -530,6 +530,19 @@ func checkSSAValue(path callgraph.Path, sources Sources, v ssa.Value, visited va
 				}
 			}
 		}
+	case *ssa.MakeMap:
+		refs := value.Referrers()
+		if refs != nil {
+			for _, ref := range *refs {
+				refVal, isVal := ref.(ssa.Value)
+				if isVal {
+					tainted, src, tv := checkSSAValue(path, sources, refVal, visited)
+					if tainted {
+						return true, src, tv
+					}
+					continue
+				}
+
 				tainted, src, tv := checkSSAInstruction(path, sources, ref, visited)
 				if tainted {
 					return true, src, tv
@@ -571,6 +584,18 @@ func checkSSAInstruction(path callgraph.Path, sources Sources, i ssa.Instruction
 			if tainted {
 				return true, src, tv
 			}
+		}
+	case *ssa.MapUpdate:
+		// Map update instructions need to be checked for both the map being updated,
+		// and the key and value being updated.
+		tainted, src, tv := checkSSAValue(path, sources, instr.Key, visited)
+		if tainted {
+			return true, src, tv
+		}
+
+		tainted, src, tv = checkSSAValue(path, sources, instr.Value, visited)
+		if tainted {
+			return true, src, tv
 		}
 	default:
 		// fmt.Printf("? check SSA instr %s: %[1]T\n", i)

--- a/check.go
+++ b/check.go
@@ -530,6 +530,12 @@ func checkSSAValue(path callgraph.Path, sources Sources, v ssa.Value, visited va
 				}
 			}
 		}
+				tainted, src, tv := checkSSAInstruction(path, sources, ref, visited)
+				if tainted {
+					return true, src, tv
+				}
+			}
+		}
 	default:
 		// fmt.Printf("? check SSA value %s: %[1]T\n", v)
 		return false, "", nil

--- a/log/injection/injection.go
+++ b/log/injection/injection.go
@@ -113,7 +113,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	// program being analyzed before running the analysis.
 	//
 	// This prevents wasting time analyzing programs that don't log.
-	if !imports(pass, "log") {
+	if !imports(pass, "log") && !imports(pass, "log/slog") {
 		return nil, nil
 	}
 

--- a/log/injection/injection.go
+++ b/log/injection/injection.go
@@ -113,7 +113,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	// program being analyzed before running the analysis.
 	//
 	// This prevents wasting time analyzing programs that don't log.
-	if !imports(pass, "log") && !imports(pass, "log/slog") {
+	if !imports(pass, "log", "log/slog") {
 		return nil, nil
 	}
 

--- a/log/injection/injection.go
+++ b/log/injection/injection.go
@@ -43,6 +43,34 @@ var injectableLogFunctions = taint.NewSinks(
 	"(*log.Logger).SetOutput",
 	"(*log.Logger).SetPrefix",
 	"(*log.Logger).Writer",
+
+	// log/slog (structured logging)
+	// https://pkg.go.dev/log/slog
+	"log/slog.Debug",
+	"log/slog.DebugContext",
+	"log/slog.Error",
+	"log/slog.ErrorContext",
+	"log/slog.Info",
+	"log/slog.InfoContext",
+	"log/slog.Warn",
+	"log/slog.WarnContext",
+	"log/slog.Log",
+	"log/slog.LogAttrs",
+	"(*log/slog.Logger).With",
+	"(*log/slog.Logger).Debug",
+	"(*log/slog.Logger).DebugContext",
+	"(*log/slog.Logger).Error",
+	"(*log/slog.Logger).ErrorContext",
+	"(*log/slog.Logger).Info",
+	"(*log/slog.Logger).InfoContext",
+	"(*log/slog.Logger).Warn",
+	"(*log/slog.Logger).WarnContext",
+	"(*log/slog.Logger).Log",
+	"(*log/slog.Logger).LogAttrs",
+	"log/slog.NewRecord",
+	"(*log/slog.Record).Add",
+	"(*log/slog.Record).AddAttrs",
+
 	// TODO: consider adding the following logger packages,
 	//       and the ability to configure this list generically.
 	//

--- a/log/injection/injection_test.go
+++ b/log/injection/injection_test.go
@@ -27,3 +27,11 @@ func TestD(t *testing.T) {
 func TestE(t *testing.T) {
 	analysistest.Run(t, testdata, Analyzer, "e")
 }
+
+func TestF(t *testing.T) {
+	analysistest.Run(t, testdata, Analyzer, "f")
+}
+
+func TestG(t *testing.T) {
+	analysistest.Run(t, testdata, Analyzer, "g")
+}

--- a/log/injection/injection_test.go
+++ b/log/injection/injection_test.go
@@ -23,3 +23,7 @@ func TestC(t *testing.T) {
 func TestD(t *testing.T) {
 	analysistest.Run(t, testdata, Analyzer, "d")
 }
+
+func TestE(t *testing.T) {
+	analysistest.Run(t, testdata, Analyzer, "e")
+}

--- a/log/injection/injection_test.go
+++ b/log/injection/injection_test.go
@@ -19,3 +19,7 @@ func TestB(t *testing.T) {
 func TestC(t *testing.T) {
 	analysistest.Run(t, testdata, Analyzer, "c")
 }
+
+func TestD(t *testing.T) {
+	analysistest.Run(t, testdata, Analyzer, "d")
+}

--- a/log/injection/testdata/src/d/main.go
+++ b/log/injection/testdata/src/d/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+func l(input string) {
+	slog.Info(input) // want "potential log injection"
+}
+
+func buisness(input string) {
+	l(input)
+}
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		input := r.URL.Query().Get("input")
+
+		f := func() {
+			buisness(input)
+		}
+
+		f()
+	})
+
+	http.ListenAndServe(":8080", nil)
+}

--- a/log/injection/testdata/src/e/main.go
+++ b/log/injection/testdata/src/e/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+)
+
+var logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+	Level: slog.LevelInfo,
+}))
+
+func l(input string) {
+	logger.InfoContext(context.Background(), "l", "input", input) // want "potential log injection"
+}
+
+func buisness(input string) {
+	l(input)
+}
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		input := r.URL.Query().Get("input")
+
+		f := func() {
+			buisness(input)
+		}
+
+		f()
+	})
+
+	http.ListenAndServe(":8080", nil)
+}

--- a/log/injection/testdata/src/f/main.go
+++ b/log/injection/testdata/src/f/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+)
+
+var logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+	Level: slog.LevelInfo,
+}))
+
+func l(input string) {
+	logger.InfoContext(context.Background(), "l", "input", map[string]string{"value": input}) // want "potential log injection"
+}
+
+func buisness(input string) {
+	l(input)
+}
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		input := r.URL.Query().Get("input")
+
+		f := func() {
+			buisness(input)
+		}
+
+		f()
+	})
+
+	http.ListenAndServe(":8080", nil)
+}

--- a/log/injection/testdata/src/g/main.go
+++ b/log/injection/testdata/src/g/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+)
+
+func l(logger *slog.Logger, input string) {
+	logger2 := logger.With("input", input).WithGroup("l") // want "potential log injection"
+
+	logger2.InfoContext(context.Background(), "l", "input", []string{input}) // want "potential log injection"
+}
+
+func buisness(logger *slog.Logger, input string) {
+	l(logger, input)
+}
+
+func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		input := r.URL.Query().Get("input")
+
+		f := func() {
+			buisness(logger, input)
+		}
+
+		f()
+	})
+
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
This PR aims to partially address #7 by adding `log/slog` function signatures to the `logi` analyzer. There's still room for additional signatures (or customization via CLI flags to consider).