### PR TITLE
Add `callgraphutil.WriteCosmograph`

### DIFF
--- a/callgraphutil/cosmograph.go
+++ b/callgraphutil/cosmograph.go
@@ -23,7 +23,7 @@ func WriteCosmograph(graph, metadata io.Writer, g *callgraph.Graph) error {
 	defer metadataWriter.Flush()
 
 	// Write header.
-	if err := graphWriter.Write([]string{"source", "target", "site"}); err != nil {
+	if err := graphWriter.Write([]string{"source", "target"}); err != nil {
 		return fmt.Errorf("failed to write header: %w", err)
 	}
 
@@ -58,7 +58,6 @@ func WriteCosmograph(graph, metadata io.Writer, g *callgraph.Graph) error {
 			if err := graphWriter.Write([]string{
 				fmt.Sprintf("%d", n.ID),
 				fmt.Sprintf("%d", e.Callee.ID),
-				fmt.Sprintf("%q", e.Site),
 			}); err != nil {
 				return fmt.Errorf("failed to write edge: %w", err)
 			}

--- a/callgraphutil/cosmograph.go
+++ b/callgraphutil/cosmograph.go
@@ -1,0 +1,69 @@
+package callgraphutil
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+
+	"golang.org/x/tools/go/callgraph"
+)
+
+// WriteComsmograph writes the given callgraph.Graph to the given io.Writer in CSV
+// format, which can be used to generate a visual representation of the call
+// graph using Comsmograph.
+//
+// https://cosmograph.app/run/
+func WriteCosmograph(graph, metadata io.Writer, g *callgraph.Graph) error {
+	graphWriter := csv.NewWriter(graph)
+	graphWriter.Comma = ';'
+	defer graphWriter.Flush()
+
+	metadataWriter := csv.NewWriter(metadata)
+	metadataWriter.Comma = ';'
+	defer metadataWriter.Flush()
+
+	// Write header.
+	if err := graphWriter.Write([]string{"source", "target", "site"}); err != nil {
+		return fmt.Errorf("failed to write header: %w", err)
+	}
+
+	// Write metadata header.
+	if err := metadataWriter.Write([]string{"id", "pkg", "func"}); err != nil {
+		return fmt.Errorf("failed to write metadata header: %w", err)
+	}
+
+	// Write edges.
+	for _, n := range g.Nodes {
+		// TODO: fix this so there's not so many "shared" functions?
+		//
+		// It is a bit of a hack, but it works for now.
+		var pkgPath string
+		if n.Func.Pkg != nil {
+			pkgPath = n.Func.Pkg.Pkg.Path()
+		} else {
+			pkgPath = "shared"
+		}
+
+		// Write metadata.
+		if err := metadataWriter.Write([]string{
+			fmt.Sprintf("%d", n.ID),
+			pkgPath,
+			n.Func.String(),
+		}); err != nil {
+			return fmt.Errorf("failed to write metadata: %w", err)
+		}
+
+		for _, e := range n.Out {
+			// Write edge.
+			if err := graphWriter.Write([]string{
+				fmt.Sprintf("%d", n.ID),
+				fmt.Sprintf("%d", e.Callee.ID),
+				fmt.Sprintf("%q", e.Site),
+			}); err != nil {
+				return fmt.Errorf("failed to write edge: %w", err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/callgraphutil/cosmograph.go
+++ b/callgraphutil/cosmograph.go
@@ -15,11 +15,11 @@ import (
 // https://cosmograph.app/run/
 func WriteCosmograph(graph, metadata io.Writer, g *callgraph.Graph) error {
 	graphWriter := csv.NewWriter(graph)
-	graphWriter.Comma = ';'
+	graphWriter.Comma = ','
 	defer graphWriter.Flush()
 
 	metadataWriter := csv.NewWriter(metadata)
-	metadataWriter.Comma = ';'
+	metadataWriter.Comma = ','
 	defer metadataWriter.Flush()
 
 	// Write header.

--- a/callgraphutil/cosmograph_test.go
+++ b/callgraphutil/cosmograph_test.go
@@ -1,0 +1,54 @@
+package callgraphutil_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/picatz/taint/callgraphutil"
+)
+
+func TestWriteCosmograph(t *testing.T) {
+	var (
+		ownerName = "picatz"
+		repoName  = "taint"
+	)
+
+	repo, _, err := cloneGitHubRepository(context.Background(), ownerName, repoName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkgs, err := loadPackages(context.Background(), repo, "./...")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mainFn, srcFns, err := loadSSA(context.Background(), pkgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cg, err := loadCallGraph(context.Background(), mainFn, srcFns)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	graphOutput, err := os.Create(fmt.Sprintf("%s.csv", repoName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer graphOutput.Close()
+
+	metadataOutput, err := os.Create(fmt.Sprintf("%s-metadata.csv", repoName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer metadataOutput.Close()
+
+	err = callgraphutil.WriteCosmograph(graphOutput, metadataOutput, cg)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR adds the `callgraphutil.WriteCosmograph` function which can write a given `*callgraph.Graph` in [Cosmograph](https://cosmograph.app/) format, outputting both the [graph and metadata](https://cosmograph.app/docs/cosmograph/How%20to%20Use#graph-mode) CSV. This enables nodes to be identified and colored by function and package names respectively. Once that's setup, functions from a specific package can be selected.

# Examples

Loading `./...` packages from different Go projects to demonstrate:

### `github.com/picatz/taint`

<img width="837" alt="Screenshot 2024-01-05 at 9 57 32 PM" src="https://github.com/picatz/taint/assets/14850816/ba179806-4d89-4d7b-bdda-883b9ca86bfa">

Selecting a specific package:

<img width="843" alt="Screenshot 2024-01-05 at 9 58 36 PM" src="https://github.com/picatz/taint/assets/14850816/e04f848f-831b-4b5a-bc2a-3aae03cbb414">

### `github.com/tailscale/tailscale`

<img width="961" alt="Screenshot 2024-01-05 at 10 14 53 PM" src="https://github.com/picatz/taint/assets/14850816/aa1017d9-3f01-4003-a3f0-a9b6045ed9fe">

### `github.com/hashicorp/vault`

<img width="959" alt="Screenshot 2024-01-05 at 10 21 24 PM" src="https://github.com/picatz/taint/assets/14850816/de2f73dc-8b2c-4d4b-9333-31f837cbd753">
