### PR TITLE
Add `callgraphutil.WriteCSV`

### DIFF
--- a/callgraphutil/csv.go
+++ b/callgraphutil/csv.go
@@ -63,6 +63,8 @@ func WriteCSV(w io.Writer, g *callgraph.Graph) error {
 	return nil
 }
 
+// nodeInfo is a struct that contains information about a callgraph.Node used
+// to generate CSV output.
 type nodeInfo struct {
 	pkgPath          string
 	pkgGoVersion     string
@@ -72,6 +74,7 @@ type nodeInfo struct {
 	pkgFuncSignature string
 }
 
+// CSV returns single record for the node.
 func (n *nodeInfo) CSV() []string {
 	return []string{
 		n.pkgPath,
@@ -83,6 +86,7 @@ func (n *nodeInfo) CSV() []string {
 	}
 }
 
+// getNodeInfo returns a nodeInfo struct for the given callgraph.Node.
 func getNodeInfo(n *callgraph.Node) (*nodeInfo, error) {
 	info := &nodeInfo{
 		pkgPath:          "unknown",

--- a/callgraphutil/csv.go
+++ b/callgraphutil/csv.go
@@ -97,7 +97,7 @@ func getNodeInfo(n *callgraph.Node) (*nodeInfo, error) {
 		info.pkgPath = n.Func.Pkg.Pkg.Path()
 
 		if goVersion := n.Func.Pkg.Pkg.GoVersion(); goVersion != "" {
-			info.pkgGoVersion = strings.TrimPrefix(goVersion, "go")
+			info.pkgGoVersion = goVersion
 		}
 	}
 

--- a/callgraphutil/csv.go
+++ b/callgraphutil/csv.go
@@ -1,0 +1,116 @@
+package callgraphutil
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+
+	"golang.org/x/tools/go/callgraph"
+)
+
+// WriteCSV writes the given callgraph.Graph to the given io.Writer in CSV
+// format. This format can be used to generate a visual representation of the
+// call graph using many different tools.
+func WriteCSV(w io.Writer, g *callgraph.Graph) error {
+	cw := csv.NewWriter(w)
+	cw.Comma = ','
+	defer cw.Flush()
+
+	// Write header.
+	if err := cw.Write([]string{
+		"source_pkg",
+		"source_pkg_go_version",
+		"source_pkg_origin",
+		"source_func",
+		"source_func_name",
+		"target_pkg",
+		"target_pkg_go_version",
+		"target_pkg_origin",
+		"target_func",
+		"target_func_name",
+	}); err != nil {
+		return fmt.Errorf("failed to write header: %w", err)
+	}
+
+	// Write edges.
+	for _, n := range g.Nodes {
+
+		var (
+			sourcePkg string
+			targetPkg string
+
+			sourceFunc string
+			targetFunc string
+
+			sourceFuncName string
+			targetFuncName string
+
+			sourcePkgOrigin string = "unknown"
+			targetPkgOrigin string = "unknown"
+
+			runtimeGoVersion   string = runtime.Version()
+			sourcePkgGoVersion string = runtimeGoVersion
+			targetPkgGoVersion string = runtimeGoVersion
+		)
+
+		if n.Func.Pkg != nil {
+			sourcePkg, sourcePkgGoVersion, sourcePkgOrigin, sourceFunc, sourceFuncName = nodeCSVInfo(n)
+		}
+
+		for _, e := range n.Out {
+			targetPkg, targetPkgGoVersion, targetPkgOrigin, targetFunc, targetFuncName = nodeCSVInfo(e.Callee)
+
+			// Write edge.
+			if err := cw.Write([]string{
+				sourcePkg,
+				sourcePkgGoVersion,
+				sourcePkgOrigin,
+				sourceFunc,
+				sourceFuncName,
+				targetPkg,
+				targetPkgGoVersion,
+				targetPkgOrigin,
+				targetFunc,
+				targetFuncName,
+			}); err != nil {
+				return fmt.Errorf("failed to write edge: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func nodeCSVInfo(n *callgraph.Node) (
+	pkgPath string,
+	pkgGoVersion string,
+	pkgOrigin string,
+	pkgFunc string,
+	pkgFuncName string,
+) {
+	pkgPath = "unknown"
+	pkgGoVersion = runtime.Version()
+	pkgOrigin = "unknown"
+	pkgFunc = n.Func.String()
+	pkgFuncName = n.Func.Name()
+
+	if n.Func.Pkg != nil {
+		pkgPath = n.Func.Pkg.Pkg.Path()
+
+		if goVersion := n.Func.Pkg.Pkg.GoVersion(); goVersion != "" {
+			pkgGoVersion = goVersion
+		}
+	}
+
+	if strings.Contains(pkgPath, ".") {
+		pkgOrigin = strings.Split(pkgPath, "/")[0]
+	} else {
+		// If the package path doesn't contain a dot, then it's probably a
+		// standard library package?
+		pkgOrigin = "stdlib"
+	}
+
+	return
+}

--- a/callgraphutil/csv_test.go
+++ b/callgraphutil/csv_test.go
@@ -1,0 +1,48 @@
+package callgraphutil_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/picatz/taint/callgraphutil"
+)
+
+func TestWriteCSV(t *testing.T) {
+	var (
+		ownerName = "picatz"
+		repoName  = "taint"
+	)
+
+	repo, _, err := cloneGitHubRepository(context.Background(), ownerName, repoName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkgs, err := loadPackages(context.Background(), repo, "./...")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mainFn, srcFns, err := loadSSA(context.Background(), pkgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cg, err := loadCallGraph(context.Background(), mainFn, srcFns)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fh, err := os.Create(fmt.Sprintf("%s.csv", repoName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fh.Close()
+
+	err = callgraphutil.WriteCSV(fh, cg)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/callgraphutil/dot_test.go
+++ b/callgraphutil/dot_test.go
@@ -8,7 +8,6 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
@@ -24,7 +23,7 @@ func cloneGitHubRepository(ctx context.Context, ownerName, repoName string) (str
 	ownerAndRepo := ownerName + "/" + repoName
 
 	// Get the directory path.
-	dir, err := os.MkdirTemp(filepath.Join(os.TempDir(), "callgraphutil_csv"), fmt.Sprintf("%s-%s", ownerName, repoName))
+	dir, err := os.MkdirTemp(os.TempDir(), fmt.Sprintf("callgraphutil_csv-%s-%s", ownerName, repoName))
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create temp dir: %w", err)
 	}

--- a/callgraphutil/dot_test.go
+++ b/callgraphutil/dot_test.go
@@ -24,25 +24,9 @@ func cloneGitHubRepository(ctx context.Context, ownerName, repoName string) (str
 	ownerAndRepo := ownerName + "/" + repoName
 
 	// Get the directory path.
-	dir := filepath.Join(os.TempDir(), "taint", "github", ownerAndRepo)
-
-	// Check if the directory exists.
-	_, err := os.Stat(dir)
-	if err == nil {
-		// If the directory exists, we'll assume it's a valid repository,
-		// and return the directory. Open the directory to
-		repo, err := git.PlainOpen(dir)
-		if err != nil {
-			return dir, "", fmt.Errorf("%w", err)
-		}
-
-		// Get the repository's HEAD.
-		head, err := repo.Head()
-		if err != nil {
-			return dir, "", fmt.Errorf("%w", err)
-		}
-
-		return dir, head.Hash().String(), nil
+	dir, err := os.MkdirTemp(filepath.Join(os.TempDir(), "callgraphutil_csv"), fmt.Sprintf("%s-%s", ownerName, repoName))
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
 
 	// Clone the repository.


### PR DESCRIPTION
This PR adds the `callgraphutil.WriteCSV` function which can write a given `*callgraph.Graph` in CSV format to an `io.Writer`.

# Example

Here are some examples of how to visualize this information with [**Observable**](https://observablehq.com/documentation/learn/overview):

<img width="1178" alt="Screenshot 2024-01-06 at 1 45 55 PM" src="https://github.com/picatz/taint/assets/14850816/413c203a-3340-4bd8-bb92-249e030d5c3a">

Looking at calls packages from this repository make to the Go standard library:

<img width="1174" alt="Screenshot 2024-01-06 at 1 38 02 PM" src="https://github.com/picatz/taint/assets/14850816/63516b07-b596-424d-80fa-fec329296265">

Looking at calls across [`tailscale`](https://github.com/tailscale/tailscale):

<img width="1110" alt="Screenshot 2024-01-09 at 10 06 38 PM" src="https://github.com/picatz/taint/assets/14850816/cc2aa5de-d96e-4262-bbdd-d6bad948e744">

> [!NOTE]
> That line going down the middle is when a package calls itself, which happens often it seems.

Here is another fun slice: 
<img width="677" alt="Screenshot 2024-01-09 at 10 08 16 PM" src="https://github.com/picatz/taint/assets/14850816/14970de9-c479-4b79-a28b-e7c03405a321">
<img width="886" alt="Screenshot 2024-01-09 at 10 09 15 PM" src="https://github.com/picatz/taint/assets/14850816/357ad1e5-818c-47c1-900b-7390e16df4e9">

Or breaking down the same information as a stacked bar chart:

<img width="1166" alt="Screenshot 2024-01-09 at 10 12 12 PM" src="https://github.com/picatz/taint/assets/14850816/015eb294-07bf-4b42-8248-4cb41c5da3db">
<img width="882" alt="Screenshot 2024-01-09 at 10 12 48 PM" src="https://github.com/picatz/taint/assets/14850816/f4dd5242-6176-4c94-a851-44fff7f62505">

Or making a force directed graph:

```javascript
data = {
  const csvData = await FileAttachment("tailscale.csv").csv();

  const links = csvData.map(d => ({source: d.source_func, target: d.target_func}));

  const nodes = Array.from(new Set(links.flatMap(l => [l.source, l.target])), id => ({id}));

  return {nodes, links};
}

ForceGraph(data, {
  nodeId: (d) => d.id,
  nodeTitle: (d) => d.id,
  width: 8000,
  height: 8000,
  invalidation // stop when the cell is re-run
})
```

![tailscale](https://github.com/picatz/taint/assets/14850816/a8b40d93-b2dc-49be-922b-a6466add02fc)


This is the one for Vault:

![vault](https://github.com/picatz/taint/assets/14850816/7cda9229-95cc-44dd-a74e-4f4c054bd40b)

We can also break this information down by package, just need to change the source and targets to use different columns from our OSV:

```javascript
data = {
  const csvData = await FileAttachment("vault.csv").csv();

  const links = csvData.map(d => ({source: d.source_pkg, target: d.target_pkg}));

  const nodes = Array.from(new Set(links.flatMap(l => [l.source, l.target])), id => ({id}));

  return {nodes, links};
}
```

![vault-pkgs](https://github.com/picatz/taint/assets/14850816/a2dce73d-e8e5-4f87-b90a-5f18c44a709d)


This is the one for Terraform:
![terraform)](https://github.com/picatz/taint/assets/14850816/abff9256-2df7-4335-9bba-8a67ab6ddd14)

This is the one for Nomad:

![nomad](https://github.com/picatz/taint/assets/14850816/72bc6fc7-b596-4253-9861-585d69863656)

This is one for Mimir: 

![mimir](https://github.com/picatz/taint/assets/14850816/eead3127-0bbc-49ed-8c92-e3a21a479175)
